### PR TITLE
[Feat] 전체적인 기능 수정 및 추가 구현

### DIFF
--- a/src/main/java/com/artfriendly/artfriendly/domain/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/auth/handler/OAuth2LoginSuccessHandler.java
@@ -50,7 +50,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         queryParams.add("isSignUp", isSignUp.toString());
 
         return UriComponentsBuilder
-                .fromHttpUrl("http://192.168.13.9:3000/login")
+                .fromHttpUrl("http://localhost:3000/login")
                 .queryParams(queryParams)
                 .build()
                 .toUri();

--- a/src/main/java/com/artfriendly/artfriendly/domain/dambyeolag/repository/DambyeolagRepository.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/dambyeolag/repository/DambyeolagRepository.java
@@ -14,6 +14,10 @@ public interface DambyeolagRepository extends JpaRepository<Dambyeolag, Long> {
             "WHERE d.id = :dambyeolagId")
     Optional<Dambyeolag> findDambyeolagById(@Param("dambyeolagId") long dambyeolagId);
 
+    @Query("SELECT d FROM Dambyeolag d " +
+            "WHERE d.exhibition.id = :exhibitionId AND d.member.id = :memberId ")
+    Optional<Dambyeolag> findDambyeolagByExhibitionIdAndMemberId(@Param("exhibitionId") long exhibitionId, @Param("memberId") long memberId);
+
     // 담벼락 스티커와 북마크가 많이 된 것 부터 정렬
     @Query("SELECT d FROM Dambyeolag d LEFT JOIN d.stickerList s LEFT JOIN d.bookmarkList m " +
             "WHERE d.exhibition.id = :exhibitionId " +

--- a/src/main/java/com/artfriendly/artfriendly/domain/exhibition/dto/ExhibitionDetailsRspDto.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/exhibition/dto/ExhibitionDetailsRspDto.java
@@ -5,6 +5,7 @@ public record ExhibitionDetailsRspDto(
         Double temperature,
         String checkTemperature,
         boolean isLike,
+        boolean hasDambyeolagWritten,
         ExhibitionInfoRspDto exhibitionInfoRspDto
 ) {
 }

--- a/src/main/java/com/artfriendly/artfriendly/domain/exhibition/mapper/ExhibitionMapper.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/exhibition/mapper/ExhibitionMapper.java
@@ -71,12 +71,13 @@ public interface ExhibitionMapper {
         return list;
     }
 
-    default ExhibitionDetailsRspDto exhibitionToExhibitionDetailsRspDto(Exhibition exhibition, String checkTemperature, boolean isLike) {
+    default ExhibitionDetailsRspDto exhibitionToExhibitionDetailsRspDto(Exhibition exhibition, String checkTemperature, boolean isLike, boolean hasDambyeolagBeenWritten) {
         return new ExhibitionDetailsRspDto(
                 exhibition.getId(),
                 exhibition.getTemperature(),
                 checkTemperature,
                 isLike,
+                hasDambyeolagBeenWritten,
                 exhibitionInfoToExhibitionInfoRspDto(exhibition.getExhibitionInfo())
         );
     }

--- a/src/main/java/com/artfriendly/artfriendly/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/exhibition/service/ExhibitionService.java
@@ -52,4 +52,6 @@ public interface ExhibitionService {
     void clearPopularExhibitionCache();
 
     void updateExhibitionList(List<ExhibitionInfo> updateExhibitionInfoList);
+
+    boolean hasDambyeolagBeenWritten(long exhibitionId, long memberId);
 }

--- a/src/main/java/com/artfriendly/artfriendly/global/exception/common/ErrorCode.java
+++ b/src/main/java/com/artfriendly/artfriendly/global/exception/common/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
     // Dambyeolag
     DAMBYEOLAG_NOT_FOUND(404, "담벼락이 존재하지 않습니다."),
     DAMBYEOLAG_NOT_ACCESS(403, "해당 담벼락 관련 권한이 없습니다."),
+    DAMBYEOLAG_ALREADY_EXIST(400, "해당 전시에 이미 담벼락이 작성되었습니다."),
     DAMBYEOLAGBOOKMARK_NOT_FOUND(404, "해당 북마크가 존재하지 않습니다."),
     DAMBYEOLAGBOOKMARK_NOT_ACCESS(403, "해당 북마크 관련 권한이 없습니다."),
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
             client-authentication-method: client_secret_post
         provider:
           kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize # 사용자 인가 코드 받아오기 ?prompt=login-> 기존 로그인에 상관없이 로그인
+            authorization-uri: https://kauth.kakao.com/oauth/authorize?prompt=login # 사용자 인가 코드 받아오기 ?prompt=login-> 기존 로그인에 상관없이 로그인
             token-uri: https://kauth.kakao.com/oauth/token # 토큰 받아오기
             user-info-uri: https://kapi.kakao.com/v2/user/me # 사용자 정보 가져오기
             user-name-attribute: id # 카카오톡의 경우 "id"를 사용한다


### PR DESCRIPTION
# 추가 사항
- 멤버당 전시 하나에 하나의 담벼락만 작성 할 수 있도록 구현
- ExhibitionDetailsRspDto에 hasDambyeolagBeenWritten 필드 추가
- 전시 희망 변경 시 캐시 초기화 되도록 구현

# 수정 사항
- 로그인 리다이렉트 주소 localhost로 롤백
- 카카오톡 상시 로그인 하도록 수정
