### PR TITLE
[Feat] Auth, Member 기능 구현

### DIFF
--- a/src/main/java/com/artfriendly/artfriendly/domain/auth/controller/OAuthMemberController.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/auth/controller/OAuthMemberController.java
@@ -1,16 +1,16 @@
 package com.artfriendly.artfriendly.domain.auth.controller;
 
+import com.artfriendly.artfriendly.domain.auth.dto.RefreshTokenRequest;
 import com.artfriendly.artfriendly.domain.member.service.MemberService;
 import com.artfriendly.artfriendly.domain.member.entity.Member;
 import com.artfriendly.artfriendly.domain.auth.cache.OAuthOTUCache;
 import com.artfriendly.artfriendly.domain.auth.dto.TokenResponse;
 import com.artfriendly.artfriendly.domain.auth.jwt.JwtTokenizer;
 import com.artfriendly.artfriendly.global.api.RspTemplate;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -28,4 +28,11 @@ public class OAuthMemberController {
         TokenResponse tokenResponse = jwtTokenizer.generateTokens(member);
         return new RspTemplate<>(HttpStatus.OK, "토큰 발급 성공", tokenResponse);
     }
+
+    @PostMapping("/token/renew")
+    public RspTemplate<TokenResponse> renewTokens(@RequestBody @Valid RefreshTokenRequest tokenRequest) {
+        TokenResponse tokenResponse = jwtTokenizer.renewTokens(tokenRequest.refreshToken());
+        return new RspTemplate<>(HttpStatus.OK, "토큰 재발급 성공", tokenResponse);
+    }
+
 }

--- a/src/main/java/com/artfriendly/artfriendly/domain/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,9 @@
+package com.artfriendly.artfriendly.domain.auth.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record RefreshTokenRequest(
+        @NotNull
+        String refreshToken
+) {
+}

--- a/src/main/java/com/artfriendly/artfriendly/domain/auth/service/JwtService.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/auth/service/JwtService.java
@@ -1,0 +1,30 @@
+package com.artfriendly.artfriendly.domain.auth.service;
+
+import com.artfriendly.artfriendly.domain.member.entity.Member;
+import com.artfriendly.artfriendly.domain.member.entity.RefreshToken;
+import com.artfriendly.artfriendly.domain.member.repository.RefreshTokenRepository;
+import com.artfriendly.artfriendly.global.exception.common.BusinessException;
+import com.artfriendly.artfriendly.global.exception.common.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JwtService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public void updateRefreshToken(String refreshToken, Member member) {
+        RefreshToken refreshTokenEntity = member.getRefreshToken();
+        refreshTokenEntity.updateRefreshToken(refreshToken);
+
+        refreshTokenRepository.save(refreshTokenEntity);
+    }
+
+    public RefreshToken findRefreshToken(String token) {
+      return refreshTokenRepository.findByToken(token).orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/artfriendly/artfriendly/domain/member/dto/MemberDetailsRspDto.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/member/dto/MemberDetailsRspDto.java
@@ -1,6 +1,7 @@
 package com.artfriendly.artfriendly.domain.member.dto;
 
 import com.artfriendly.artfriendly.domain.mbti.dto.MbtiSimpleRspDto;
+import com.artfriendly.artfriendly.domain.member.entity.Member;
 
 import java.util.List;
 
@@ -10,6 +11,7 @@ public record MemberDetailsRspDto(
         String imageUrl,
         String nickName,
         String selfIntro,
+        Member.MemberStatus status,
         MbtiSimpleRspDto mbtiSimpleRspDto,
         List<String> artPreferenceTypeList
 ) {

--- a/src/main/java/com/artfriendly/artfriendly/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/member/dto/MemberResponseDto.java
@@ -1,9 +1,12 @@
 package com.artfriendly.artfriendly.domain.member.dto;
 
+import com.artfriendly.artfriendly.domain.member.entity.Member;
+
 public record MemberResponseDto(
     Long id,
     String email,
     String imageUrl,
-    String nickName
+    String nickName,
+    Member.MemberStatus status
 ) {
 }

--- a/src/main/java/com/artfriendly/artfriendly/domain/member/entity/Member.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/member/entity/Member.java
@@ -38,6 +38,9 @@ public class Member extends BaseTimeEntity {
     @Column
     private String selfIntro;
 
+    @Column
+    private MemberStatus status = MemberStatus.MEMBER_ACTIVE;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mbti_id")
     private Mbti mbti;
@@ -61,6 +64,8 @@ public class Member extends BaseTimeEntity {
     List<ExhibitionHope> exhibitionHopeList = new ArrayList<>();
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     List<ExhibitionView> exhibitionViewList = new ArrayList<>();
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    RefreshToken refreshToken;
 
     @Builder
     public Member(Long id, String email, String nickName, MemberImage image, String selfIntro, List<String> role, List<String> artPreferenceTypeList, Mbti mbti) {
@@ -92,11 +97,26 @@ public class Member extends BaseTimeEntity {
         this.nickName = "탈퇴한 멤버";
         this.selfIntro = null;
         this.mbti = null;
+        this.status = MemberStatus.MEMBER_QUIT;
         this.role = null;
         this.artPreferenceTypeList = null;
+        this.refreshToken = null;
+    }
+
+    @Getter
+    public enum MemberStatus {
+        MEMBER_ACTIVE("활동중"),
+        MEMBER_QUIT("탈퇴 상태");
+
+        private final String status;
+
+        MemberStatus(String status) {
+            this.status = status;
+        }
     }
 
     public void setImage(MemberImage memberImage) { this.image = memberImage; }
+    public void setRefreshToken(RefreshToken refreshToken) { this.refreshToken = refreshToken; }
     public void setDambyeolagBookmarkList(List<DambyeolagBookmark> dambyeolagBookmarkList) { this.dambyeolagBookmarkList = dambyeolagBookmarkList; }
     public void grantRoles(List<String> role) { this.role.addAll(role); }
 }

--- a/src/main/java/com/artfriendly/artfriendly/domain/member/entity/RefreshToken.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/member/entity/RefreshToken.java
@@ -1,0 +1,33 @@
+package com.artfriendly.artfriendly.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String token;
+
+    @OneToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "member_id")
+    Member member;
+
+    @Builder
+    public RefreshToken(String token, Member member) {
+        this.token = token;
+        this.member = member;
+    }
+
+    public void updateRefreshToken(String updateRefreshToken) {
+        this.token = updateRefreshToken;
+    }
+}

--- a/src/main/java/com/artfriendly/artfriendly/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/member/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.artfriendly.artfriendly.domain.member.repository;
+
+import com.artfriendly.artfriendly.domain.member.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+}

--- a/src/main/java/com/artfriendly/artfriendly/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/artfriendly/artfriendly/domain/member/service/MemberServiceImpl.java
@@ -2,6 +2,7 @@ package com.artfriendly.artfriendly.domain.member.service;
 
 import com.artfriendly.artfriendly.domain.auth.dto.OAuth2Attributes;
 import com.artfriendly.artfriendly.domain.auth.dto.OAuth2LoginDto;
+import com.artfriendly.artfriendly.domain.member.entity.RefreshToken;
 import com.artfriendly.artfriendly.domain.member.event.MemberEventPublisher;
 import com.artfriendly.artfriendly.domain.member.dto.MemberDetailsRspDto;
 import com.artfriendly.artfriendly.domain.member.dto.MemberUpdateReqDto;
@@ -80,6 +81,12 @@ public class MemberServiceImpl implements MemberService {
                 .member(member)
                 .build();
 
+        RefreshToken refreshToken = RefreshToken.builder()
+                .token(null)
+                .member(member)
+                .build();
+
+        member.setRefreshToken(refreshToken);
         member.setImage(memberImage);
         return memberRepository.save(member);
     }
@@ -99,6 +106,8 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public ProfileDto getProfileDto(long memberId) {
         Member member = findById(memberId);
+        if(!member.getStatus().equals(Member.MemberStatus.MEMBER_ACTIVE))
+            throw new BusinessException(ErrorCode.USER_STATUS_WITHDRAWN);
         return memberMapper.memberToProfileDto(member);
     }
 

--- a/src/main/java/com/artfriendly/artfriendly/global/exception/common/ErrorCode.java
+++ b/src/main/java/com/artfriendly/artfriendly/global/exception/common/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 
     // 사용자
     USER_NOT_FOUND(404, "해당 사용자가 존재하지 않습니다."),
+    USER_STATUS_WITHDRAWN(400, "해당 유저는 이미 탈퇴한 유저입니다."),
 
     // 파일
     INVALID_FILE_EXTENSION(400, "파일 확장자가 유효하지 않습니다."),


### PR DESCRIPTION
# 추가 사항
- 탈퇴한 멤버의 프로필 조회하지 못하도록 구현
- Member에 MemberStatus enum, status 필드 추가
- MemberDetailsRspDto, MemberResponseDto에 status 필드 추가
- refreshToken을 통해 토큰을 재발급 하는 기능 구현
- RefreshToken 테이블 생성

# 수정 사항
- 없음